### PR TITLE
import DataError from pycomm.cip.cip_base

### DIFF
--- a/eip_bridge/src/eip_bridge/eip_bridge.py
+++ b/eip_bridge/src/eip_bridge/eip_bridge.py
@@ -5,7 +5,7 @@ from eip_msgs.srv import SetMode
 from eip_msgs.srv import SetModeRequest
 from eip_msgs.srv import SetModeResponse
 
-from pycomm.ab_comm.clx import DataError
+from pycomm.cip.cip_base import DataError
 from pycomm.cip.cip_base import CommError
 import rospy
 from time import sleep


### PR DESCRIPTION
`DataError` is defined in `cip_base.py` and not overwritten in [clx](https://github.com/ruscito/pycomm/blob/master/pycomm/ab_comm/clx.py), so I think it make sense to import from `cip_base.py` file.

https://github.com/ruscito/pycomm/blob/4827be0ccb0732ab68a874d5a7b7d9f0479227b1/pycomm/cip/cip_base.py#L51

FYI: @yuki-asano